### PR TITLE
Integration with Unite, if installed

### DIFF
--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -151,11 +151,15 @@ function! BookmarkShowAll()
     let oldformat = &errorformat    " backup original format
     let &errorformat = "%f:%l:%m"   " custom format for bookmarks
     cgetexpr bm#location_list()
-    belowright copen
-    augroup BM_AutoCloseCommand
-      autocmd!
-      autocmd WinLeave * call s:auto_close()
-    augroup END
+    if exists(':Unite') && !empty(unite#get_all_sources('quickfix'))
+      exec ":Unite quickfix"
+    else
+      belowright copen
+      augroup BM_AutoCloseCommand
+        autocmd!
+        autocmd WinLeave * call s:auto_close()
+      augroup END
+    endif
     let &errorformat = oldformat    " re-apply original format
   endif
 endfunction


### PR DESCRIPTION
[Unite](https://github.com/Shougo/unite.vim) is a multi-purpose plugin platform for Vim. I've changed `BookmarkShowAll()` to check if Unite is installed and has a source named 'quickfix', if it's installed, open it instead of the quickfix window.
