### PR TITLE
Restore quickfix window space to window above instead of to window below

### DIFF
--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -324,7 +324,13 @@ endfunction
 function! s:auto_close()
   if s:is_quickfix_win()
     if (g:bookmark_auto_close)
+      " Setting 'splitbelow' before closing the quickfix window will ensure
+      " that its space is given back to the window above rather than to the
+      " window below.
+      let l:sb = &sb
+      set splitbelow
       q
+      let &sb = l:sb
     endif
     call s:remove_auto_close()
   endif


### PR DESCRIPTION
As described in my e-mail of 2014-11-05, when using 'noequalalways' and g:bookmark_auto_close and working in a split window other than the bottom window, the ma command will take the space for the quickfix window from the current window, but closing the quckfix window will return its space to the window below. This means that after executing ma and selecting a bookmark, the window will be smaller than it was to start with. This change fixes that problem.
