### PR TITLE
Do not close unite interface on 'delete' action

### DIFF
--- a/autoload/unite/kinds/vim_bookmarks.vim
+++ b/autoload/unite/kinds/vim_bookmarks.vim
@@ -10,6 +10,7 @@ let s:kind = {
       \   'delete': {
       \     'description': 'delete the selected bookmarks',
       \     'is_selectable': 1,
+      \     'is_quit': 0,
       \   },
       \   'yank': {
       \     'description': 'yank path and content of the selected bookmarks',
@@ -48,6 +49,7 @@ function! s:kind.action_table.delete.func(candidates) " {{{
           \ candidate.action__line,
           \)
   endfor
+  call unite#force_redraw()
 endfunction " }}}
 function! s:kind.action_table.yank.func(candidates) " {{{
   let text = join(map(copy(a:candidates),


### PR DESCRIPTION
As I mentioned. I updated the behavior of vim-bookmarks' Unite interface. Now a 'delete' action of vim-bookmarks do not close the Unite interface.
With this update, users can open a bookmark **directly after** bookmark re-arrangement (removing unnecessary bookmarks).

It will close https://github.com/MattesGroeger/vim-bookmarks/issues/70