### PR TITLE
Added option to manage bookmarks per buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 VimFlavor.lock
 .vim-flavor
 tags
+.*.swp

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Put any of the following options into your `~/.vimrc` in order to overwrite the 
 | `let g:bookmark_annotation_sign = '##'`        | ☰                        | Sets bookmark annotation icon for sign column           |
 | `let g:bookmark_save_per_working_dir = 1`      | 0                        | Save bookmarks per working dir, the folder you opened vim from |
 | `let g:bookmark_auto_save = 0`                 | 1                        | Enables/disables automatic saving for bookmarks         |
-| `let g:bookmark_manage_per_buffer = 0`         | 0                        | Save bookmarks when leaving a buffer, load when entering one |
+| `let g:bookmark_manage_per_buffer = 1`         | 0                        | Save bookmarks when leaving a buffer, load when entering one |
 | `let g:bookmark_auto_save_file = '/bookmarks'` | $HOME .'/.vim-bookmarks' | Sets file for auto saving (ignored when `bookmark_save_per_working_dir` is enabled) |
 | `let g:bookmark_auto_close = 1`                | 0                        | Automatically close bookmarks split when jumping to a bookmark |
 | `let g:bookmark_highlight_lines = 1`           | 0                        | Enables/disables line highlighting                      |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Put any of the following options into your `~/.vimrc` in order to overwrite the 
 | `let g:bookmark_annotation_sign = '##'`        | ☰                        | Sets bookmark annotation icon for sign column           |
 | `let g:bookmark_save_per_working_dir = 1`      | 0                        | Save bookmarks per working dir, the folder you opened vim from |
 | `let g:bookmark_auto_save = 0`                 | 1                        | Enables/disables automatic saving for bookmarks         |
+| `let g:bookmark_auto_save_per_buffer = 0`      | 0                        | Save bookmarks when leaving a buffer, load when entering one |
 | `let g:bookmark_auto_save_file = '/bookmarks'` | $HOME .'/.vim-bookmarks' | Sets file for auto saving (ignored when `bookmark_save_per_working_dir` is enabled) |
 | `let g:bookmark_auto_close = 1`                | 0                        | Automatically close bookmarks split when jumping to a bookmark |
 | `let g:bookmark_highlight_lines = 1`           | 0                        | Enables/disables line highlighting                      |
@@ -144,6 +145,27 @@ function! g:BMWorkDirFileLocation()
         return location.'/'.filename
     else
         return getcwd().'/.'.filename
+    endif
+endfunction
+```
+
+And if you choose to save bookmarks automatically per buffer, use this:
+```viml
+" Finds the Git super-project directory based on the file passed as an argument.
+function! g:BMBufferFileLocation(file)
+    let filename = 'vim-bookmarks'
+    let location = ''
+    if isdirectory(fnamemodify(a:file, ":p:h").'/.git')
+        " Current work dir is git's work tree
+        let location = fnamemodify(a:file, ":p:h")
+    else
+        " Look upwards (at parents) for a directory named '.git'
+        let location = finddir('.git', fnamemodify(a:file, ":p:h").'/.;').'/..'
+    endif
+    if len(location) > 0
+        return simplify(location.'/.'.filename)
+    else
+        return simplify(fnamemodify(a:file, ":p:h").'/.'.filename)
     endif
 endfunction
 ```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Put any of the following options into your `~/.vimrc` in order to overwrite the 
 | `let g:bookmark_annotation_sign = '##'`        | ☰                        | Sets bookmark annotation icon for sign column           |
 | `let g:bookmark_save_per_working_dir = 1`      | 0                        | Save bookmarks per working dir, the folder you opened vim from |
 | `let g:bookmark_auto_save = 0`                 | 1                        | Enables/disables automatic saving for bookmarks         |
-| `let g:bookmark_auto_save_per_buffer = 0`      | 0                        | Save bookmarks when leaving a buffer, load when entering one |
+| `let g:bookmark_manage_per_buffer = 0`         | 0                        | Save bookmarks when leaving a buffer, load when entering one |
 | `let g:bookmark_auto_save_file = '/bookmarks'` | $HOME .'/.vim-bookmarks' | Sets file for auto saving (ignored when `bookmark_save_per_working_dir` is enabled) |
 | `let g:bookmark_auto_close = 1`                | 0                        | Automatically close bookmarks split when jumping to a bookmark |
 | `let g:bookmark_highlight_lines = 1`           | 0                        | Enables/disables line highlighting                      |
@@ -149,7 +149,7 @@ function! g:BMWorkDirFileLocation()
 endfunction
 ```
 
-And if you choose to save bookmarks automatically per buffer, use this:
+And if you choose to manage bookmarks per buffer, use this:
 ```viml
 " Finds the Git super-project directory based on the file passed as an argument.
 function! g:BMBufferFileLocation(file)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,22 @@ function! g:BMWorkDirFileLocation()
 endfunction
 ```
 
-And if you choose to manage bookmarks per buffer, use this:
+### Bookmarks per buffer
+
+This feature implies `bookmark_auto_save`. When configured bookmarks will be
+loaded and saved on each buffer change. This allows working with different
+buffers/tabs and keeping a different bookmark file for each one based on the
+file open in the buffer. I.e., using the following function and having files
+from different Git repositories open in different tabs will use a different
+bookmarks file per Git repository.
+
+This is different from how saving per working directory works because it allows
+for having different bookmarks for different buffers/tabs open in the same
+window without having the working directory change automatically when switching
+between them.
+
+The following function is similar to the one shown above (finds the .git folder
+location, defaults to current file's directory) :
 ```viml
 " Finds the Git super-project directory based on the file passed as an argument.
 function! g:BMBufferFileLocation(file)
@@ -157,10 +172,10 @@ function! g:BMBufferFileLocation(file)
     let location = ''
     if isdirectory(fnamemodify(a:file, ":p:h").'/.git')
         " Current work dir is git's work tree
-        let location = fnamemodify(a:file, ":p:h")
+        let location = fnamemodify(a:file, ":p:h").'/.git'
     else
         " Look upwards (at parents) for a directory named '.git'
-        let location = finddir('.git', fnamemodify(a:file, ":p:h").'/.;').'/..'
+        let location = finddir('.git', fnamemodify(a:file, ":p:h").'/.;')
     endif
     if len(location) > 0
         return simplify(location.'/.'.filename)

--- a/doc/bookmarks.txt
+++ b/doc/bookmarks.txt
@@ -184,6 +184,16 @@ the current working directory whenever you create bookmarks. You should add this
 file to your (global) `.gitignore` file so it doesn't get checked into version
 control.
 
+Enable bookmark management on a per buffer basis:
+
+>
+  let g:bookmark_manage_per_buffer = 1
+<
+
+This will save and load the bookmarks file whenever the buffer changes (e.g.,
+switching tabs/buffers). It makes most sense when g:bookmark_save_per_working_dir
+is turned on as well, or when a customizing function is used.
+
 Disable auto saving (default 1):
 
 >

--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -34,7 +34,8 @@ function! s:init(file)
       autocmd!
       autocmd BufEnter * call s:set_up_auto_save(expand('<afile>:p'))
     augroup END
-  else
+  endif
+  if a:file !=# ''
     call s:set_up_auto_save(a:file)
   endif
 endfunction

--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -308,8 +308,14 @@ function! s:startup_load_bookmarks(file)
 endfunction
 
 function! s:bookmark_save_file(file)
-  if (g:bookmark_save_per_working_dir)
-    return exists("*g:BMWorkDirFileLocation") ? g:BMWorkDirFileLocation(a:file) : s:default_file_location()
+  " per buffer and per working dir are not mutually exclusive, but for the sake
+  " of determining the file to save bookmarks in, they pretty much are due to
+  " the different custom handlers used to compute that file name.
+  " This is purely a result of keeping the code backward compatible.
+  if (g:bookmark_auto_save_per_buffer ==# 1)
+    return exists("*g:BMBufferFileLocation") ? g:BMBufferFileLocation(a:file) : s:default_file_location()
+  elseif (g:bookmark_save_per_working_dir)
+    return exists("*g:BMWorkDirFileLocation") ? g:BMWorkDirFileLocation() : s:default_file_location()
   else
     return g:bookmark_auto_save_file
   endif

--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -23,13 +23,13 @@ call s:set('g:bookmark_annotation_sign',     '☰')
 call s:set('g:bookmark_show_warning',         1 )
 call s:set('g:bookmark_save_per_working_dir', 0 )
 call s:set('g:bookmark_auto_save',            1 )
-call s:set('g:bookmark_auto_save_per_buffer', 0 )
+call s:set('g:bookmark_manage_per_buffer',    0 )
 call s:set('g:bookmark_auto_save_file',       $HOME .'/.vim-bookmarks')
 call s:set('g:bookmark_auto_close',           0 )
 call s:set('g:bookmark_center',               0 )
 
 function! s:init(file)
-  if g:bookmark_auto_save ==# 1 && g:bookmark_auto_save_per_buffer ==# 1
+  if g:bookmark_auto_save ==# 1 && g:bookmark_manage_per_buffer ==# 1
     augroup bm_vim_enter
       autocmd!
       autocmd BufEnter * call s:set_up_auto_save(expand('<afile>:p'))
@@ -312,7 +312,7 @@ function! s:bookmark_save_file(file)
   " of determining the file to save bookmarks in, they pretty much are due to
   " the different custom handlers used to compute that file name.
   " This is purely a result of keeping the code backward compatible.
-  if (g:bookmark_auto_save_per_buffer ==# 1)
+  if (g:bookmark_manage_per_buffer ==# 1)
     return exists("*g:BMBufferFileLocation") ? g:BMBufferFileLocation(a:file) : s:default_file_location()
   elseif (g:bookmark_save_per_working_dir)
     return exists("*g:BMWorkDirFileLocation") ? g:BMWorkDirFileLocation() : s:default_file_location()
@@ -375,7 +375,7 @@ function! s:set_up_auto_save(file)
        autocmd!
        autocmd BufWinEnter * call s:add_missing_signs(expand('<afile>:p'))
      augroup END
-     if g:bookmark_auto_save_per_buffer ==# 1
+     if g:bookmark_manage_per_buffer ==# 1
        augroup bm_auto_save
          autocmd BufLeave * call s:auto_save()
        augroup END


### PR DESCRIPTION
This allows for different tabs/buffers to have different bookmarks lists, instead of only a window-wide list that is either work dir based or truly global for the user.

All tests have passed.