### PR TITLE
Specify scriptencoding utf-8 in plugin/bookmark.vim

### DIFF
--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -1,6 +1,8 @@
 if exists('g:bm_has_any') || !has('signs') || &cp
   finish
 endif
+scriptencoding utf-8
+
 let g:bm_has_any = 0
 let g:bm_sign_index = 9500
 let g:bm_current_file = ''


### PR DESCRIPTION
My gvim reports such a error in MS-Windows(Simplified Chinese).
![vim-book-script](https://cloud.githubusercontent.com/assets/2666324/8525611/8960caca-2434-11e5-844f-ac8391fd5609.png)
The default encoding used inside my vim is not utf-8, but cp936. The char bookmark_sign and bookmark_annotation_sign can't be recognized.
![encoding2](https://cloud.githubusercontent.com/assets/2666324/8526258/1e1b0858-2438-11e5-896e-3ec1cd90734f.png)

I can fix the problem by 2 ways:
1. add "set encoding=utf-8" in my vimrc
2. or add "scriptencoding utf-8" in vim-bookmarks script.
