### PR TITLE
fixes issue #86

### DIFF
--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -206,7 +206,7 @@ command! -nargs=1 BookmarkSave call BookmarkSave(<f-args>, 0)
 function! BookmarkLoad(target_file, startup, silent)
   let supports_confirm = has("dialog_con") || has("dialog_gui")
   let has_bookmarks = bm#total_count() ># 0
-  let confirmed = 1
+  let confirmed = 0
   if (supports_confirm && has_bookmarks && !a:silent)
     let confirmed = confirm("Do you want to override your ". bm#total_count() ." bookmarks?", "&Yes\n&No")
   endif


### PR DESCRIPTION
In silent mode, all bookmarks are cleared without asking the user.  While using the auto save feature BookmarkLoad method is invoked every time the autocommand is triggered clearing all bookmarks in the process.  This change fixes it.