### PR TITLE
bookmarks cleared on switching buffers.

### DIFF
--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -423,17 +423,9 @@ function! s:set_up_auto_save(file)
      augroup bm_auto_save
        autocmd!
        autocmd BufWinEnter * call s:add_missing_signs(expand('<afile>:p'))
+       autocmd BufLeave * call s:auto_save()
+       autocmd VimLeave * call s:auto_save()
      augroup END
-     if g:bookmark_manage_per_buffer ==# 1
-       augroup bm_auto_save
-         autocmd BufLeave * call s:auto_save()
-         autocmd VimLeave * call s:auto_save()
-       augroup END
-     else
-       augroup bm_auto_save
-         autocmd VimLeave * call s:auto_save()
-       augroup END
-     endif
    endif
 endfunction
 

--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -423,8 +423,7 @@ function! s:set_up_auto_save(file)
      augroup bm_auto_save
        autocmd!
        autocmd BufWinEnter * call s:add_missing_signs(expand('<afile>:p'))
-       autocmd BufLeave * call s:auto_save()
-       autocmd VimLeave * call s:auto_save()
+       autocmd BufLeave,VimLeave * call s:auto_save()
      augroup END
    endif
 endfunction


### PR DESCRIPTION
If g:bookmark_manage_per_buffer is set to 0, bookmarks are cleared on switching buffers.  This is because the save method is not invoked on the BufLeave event.  A BufEnter is triggered and this clears all bookmarks.