### PR TITLE
Show bookmarks using location list

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Put any of the following options into your `~/.vimrc` in order to overwrite the 
 | `let g:bookmark_show_toggle_warning = 0`       | 1                        | Enables/disables warning when toggling to clear a bookmark with annotation   |
 | `let g:bookmark_center = 1`                    | 0                        | Enables/disables line centering when jumping to bookmark|
 | `let g:bookmark_no_default_key_mappings = 1`                    | 0                        | Prevent any default key mapping from being created|
+| `let g:bookmark_location_list = 1`             | 0                        | Use the location list to show all bookmarks             |
 
 ### Bookmarks per working directory
 
@@ -273,6 +274,10 @@ endfunction
 autocmd BufEnter * :call BookmarkMapKeys()
 autocmd BufEnter NERD_tree_* :call BookmarkUnmapKeys()
 ```
+
+> Why do my bookmarks disappear when running the `:make` command?
+
+By default, the bookmark list is shown using the quickfix window, which can sometimes conflict with other commands. The location list may be used to show the bookmark list instead by setting the `g:bookmark_location_list` option documented above.
 
 ## Changelog
 

--- a/doc/bookmarks.txt
+++ b/doc/bookmarks.txt
@@ -243,6 +243,12 @@ Automatically close bookmarks split when jumping to a bookmark (default 0):
 >
   let g:bookmark_auto_close = 1
 <
+
+Use the location list to show all bookmarks (default 0):
+
+>
+  let g:bookmark_location_list = 1
+<
 ===============================================================================
 6. EXTENDING                                               *BookmarksExtending*
 

--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -30,6 +30,7 @@ call s:set('g:bookmark_manage_per_buffer',    0 )
 call s:set('g:bookmark_auto_save_file',       $HOME .'/.vim-bookmarks')
 call s:set('g:bookmark_auto_close',           0 )
 call s:set('g:bookmark_center',               0 )
+call s:set('g:bookmark_location_list',        0 )
 
 function! s:init(file)
   if g:bookmark_auto_save ==# 1 || g:bookmark_manage_per_buffer ==# 1
@@ -175,8 +176,13 @@ function! BookmarkShowAll()
     else
       let oldformat = &errorformat    " backup original format
       let &errorformat = "%f:%l:%m"   " custom format for bookmarks
-      cgetexpr bm#location_list()
-      belowright copen
+      if g:bookmark_location_list
+        lgetexpr bm#location_list()
+        belowright lopen
+      else
+        cgetexpr bm#location_list()
+        belowright copen
+      endif
       augroup BM_AutoCloseCommand
         autocmd!
         autocmd WinLeave * call s:auto_close()


### PR DESCRIPTION
This PR addresses Issue #96 by adding a new option to display bookmarks using the location list. This allows vim-bookmarks to be used concurrently with other quickfix commands like `make`. 