### PR TITLE
Register the <Plug> commands even when default key mappings are disabled

### DIFF
--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -443,21 +443,21 @@ endfunction
 
 function! s:register_mapping(command, shortcut)
   execute "nnoremap <silent> <Plug>". a:command ." :". a:command ."<CR>"
-  if !hasmapto("<Plug>". a:command) && maparg(a:shortcut, 'n') ==# ''
+  if !hasmapto("<Plug>". a:command)
+        \ && !get(g:, 'bookmark_no_default_key_mappings', 0)
+        \ && maparg(a:shortcut, 'n') ==# ''
     execute "nmap ". a:shortcut ." <Plug>". a:command
   endif
 endfunction
 
-if !get(g:, 'bookmark_no_default_key_mappings', 0)
-  call s:register_mapping('BookmarkShowAll',  'ma')
-  call s:register_mapping('BookmarkToggle',   'mm')
-  call s:register_mapping('BookmarkAnnotate', 'mi')
-  call s:register_mapping('BookmarkNext',     'mn')
-  call s:register_mapping('BookmarkPrev',     'mp')
-  call s:register_mapping('BookmarkClear',    'mc')
-  call s:register_mapping('BookmarkClearAll', 'mx')
-  call s:register_mapping('BookmarkMoveUp', 'mkk')
-  call s:register_mapping('BookmarkMoveDown', 'mjj')
-endif
+call s:register_mapping('BookmarkShowAll',  'ma')
+call s:register_mapping('BookmarkToggle',   'mm')
+call s:register_mapping('BookmarkAnnotate', 'mi')
+call s:register_mapping('BookmarkNext',     'mn')
+call s:register_mapping('BookmarkPrev',     'mp')
+call s:register_mapping('BookmarkClear',    'mc')
+call s:register_mapping('BookmarkClearAll', 'mx')
+call s:register_mapping('BookmarkMoveUp', 'mkk')
+call s:register_mapping('BookmarkMoveDown', 'mjj')
 
 " }}}


### PR DESCRIPTION
Followup to #68, #69

The check for `bookmark_no_default_key_mappings` was too aggressive, not
registering the <Plug> aliases at all. This meant that the instructions for
overriding shortcuts from the README did not work.

This change moves the check of that global to the place where the default
shortcuts are actually added after the <Plug> alias is regsitered.