### PR TITLE
fix #110.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ let g:bookmark_highlight_lines = 1
 * [Bookmarks per working directory](https://github.com/MattesGroeger/vim-bookmarks#bookmarks-per-working-directory) (optional)
 * Fully customisable (signs, sign column, highlights, mappings)
 * Integrates with [Unite's](https://github.com/Shougo/unite.vim) quickfix source if installed
+* Integrates with [ctrlp.vim](https://github.com/ctrlpvim/ctrlp.vim) if installed
 * Works independently from [vim marks](http://vim.wikia.com/wiki/Using_marks)
 
 ## Installation
@@ -117,6 +118,7 @@ Put any of the following options into your `~/.vimrc` in order to overwrite the 
 | `let g:bookmark_center = 1`                    | 0                        | Enables/disables line centering when jumping to bookmark|
 | `let g:bookmark_no_default_key_mappings = 1`                    | 0                        | Prevent any default key mapping from being created|
 | `let g:bookmark_location_list = 1`             | 0                        | Use the location list to show all bookmarks             |
+| `let g:bookmark_disable_ctrlp = 1`             | 0                        | Disable ctrlp interface when  show all bookmarks             |
 
 ### Bookmarks per working directory
 

--- a/autoload/ctrlp/bookmarks.vim
+++ b/autoload/ctrlp/bookmarks.vim
@@ -20,7 +20,11 @@ function! ctrlp#bookmarks#init() abort
         let l:line_nrs = sort(bm#all_lines(l:file), "bm#compare_lines")
         for l:line_nr in l:line_nrs
             let l:bookmark = bm#get_bookmark_by_line(l:file, l:line_nr)
-            call add(l:text,l:bookmark.annotation)
+            if l:bookmark.annotation !~ '^\s*$'
+              call add(l:text,l:bookmark.annotation)
+            else
+              call add(l:text,l:bookmark.content)
+            endif
         endfor
     endfor
     return l:text
@@ -43,7 +47,11 @@ function! ctrlp#bookmarks#accept(mode, str) abort
         let l:line_nrs = sort(bm#all_lines(l:file), "bm#compare_lines")
         for l:line_nr in l:line_nrs
             let l:bookmark = bm#get_bookmark_by_line(l:file, l:line_nr)
-            if a:str ==# l:bookmark.annotation
+            if a:str ==# l:bookmark.annotation 
+                execute l:HowToOpen." ".l:file
+                execute ":".l:line_nr
+                break
+            elseif a:str ==# l:bookmark.content
                 execute l:HowToOpen." ".l:file
                 execute ":".l:line_nr
                 break

--- a/doc/bookmarks.txt
+++ b/doc/bookmarks.txt
@@ -249,6 +249,11 @@ Use the location list to show all bookmarks (default 0):
 
 >
   let g:bookmark_location_list = 1
+
+
+You can disable Ctrlp by setting (default 0)
+>
+  let g:bookmark_disable_ctrlp = 1
 <
 ===============================================================================
 6. EXTENDING                                               *BookmarksExtending*

--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -31,6 +31,7 @@ call s:set('g:bookmark_auto_save_file',       $HOME .'/.vim-bookmarks')
 call s:set('g:bookmark_auto_close',           0 )
 call s:set('g:bookmark_center',               0 )
 call s:set('g:bookmark_location_list',        0 )
+call s:set('g:bookmark_disable_ctrlp',        0 )
 
 function! s:init(file)
   if g:bookmark_auto_save ==# 1 || g:bookmark_manage_per_buffer ==# 1
@@ -176,7 +177,7 @@ function! BookmarkShowAll()
     call s:refresh_line_numbers()
     if exists(':Unite')
         exec ":Unite vim_bookmarks"
-    elseif exists(':CtrlP') == 2
+    elseif exists(':CtrlP') == 2 && g:bookmark_disable_ctrlp == 0
         exec ":CtrlPBookmark"
     else
       let oldformat = &errorformat    " backup original format


### PR DESCRIPTION
1. annotation field will empty when user run BookmarkToggle.
   Use content field instead in this situation.
2. Add a new global option:g:bookmark_disable_ctrlp to disable
   CtrlP interface in BookmarkShowAll(default is 0,enable)
3. Update doc.