### PR TITLE
Use $PWD instead of getcwd()

### DIFF
--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -383,7 +383,7 @@ function! s:bookmark_save_file(file)
 endfunction
 
 function! s:default_file_location()
-    return getcwd(). '/.vim-bookmarks'
+    return $PWD . '/.vim-bookmarks'
 endfunction
 
 " should only be called from autocmd!


### PR DESCRIPTION
From README on `g:bookmark_save_per_working_dir` (emphasis mine):
> This is done by saving a file called .vim-bookmarks into the current working directory (**the folder you opened vim from**...

But `getcwd()` will get the "current effective directory" which will vary based on `:tcd` or `:lcd` effectively saving `.vim-bookmarks` in random locations. I think it is more predictable to use `$PWD` for the default save location.