### PR TITLE
Protect <Plug> mappings names with parenthesis to avoid timeout delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,16 @@ You can change the shortcuts as you like, just read on...
 You can overwrite any of the default mappings. Just put the following into your `~/.vimrc` and adjust as you like:
 
 ```viml
-nmap <Leader><Leader> <Plug>BookmarkToggle
-nmap <Leader>i <Plug>BookmarkAnnotate
-nmap <Leader>a <Plug>BookmarkShowAll
-nmap <Leader>j <Plug>BookmarkNext
-nmap <Leader>k <Plug>BookmarkPrev
-nmap <Leader>c <Plug>BookmarkClear
-nmap <Leader>x <Plug>BookmarkClearAll
-nmap <Leader>kk <Plug>BookmarkMoveUp
-nmap <Leader>jj <Plug>BookmarkMoveDown
-nmap <Leader>g <Plug>BookmarkMoveToLine
+nmap <Leader><Leader> <Plug>(BookmarkToggle)
+nmap <Leader>i <Plug>(BookmarkAnnotate)
+nmap <Leader>a <Plug>(BookmarkShowAll)
+nmap <Leader>j <Plug>(BookmarkNext)
+nmap <Leader>k <Plug>(BookmarkPrev)
+nmap <Leader>c <Plug>(BookmarkClear)
+nmap <Leader>x <Plug>(BookmarkClearAll)
+nmap <Leader>kk <Plug>(BookmarkMoveUp)
+nmap <Leader>jj <Plug>(BookmarkMoveDown)
+nmap <Leader>g <Plug>(BookmarkMoveToLine)
 ```
 You can disable all default key bindings by setting the following in your `~/.vimrc`:
 

--- a/doc/bookmarks.txt
+++ b/doc/bookmarks.txt
@@ -167,18 +167,18 @@ KEY MAPPINGS
 
 To change the default keys:
 >
-  nmap <Leader><Leader> <Plug>BookmarkToggle
-  nmap <Leader>i <Plug>BookmarkAnnotate
-  nmap <Leader>a <Plug>BookmarkShowAll
-  nmap <Leader>j <Plug>BookmarkNext
-  nmap <Leader>k <Plug>BookmarkPrev
-  nmap <Leader>c <Plug>BookmarkClear
-  nmap <Leader>x <Plug>BookmarkClearAll
+  nmap <Leader><Leader> <Plug>(BookmarkToggle)
+  nmap <Leader>i <Plug>(BookmarkAnnotate)
+  nmap <Leader>a <Plug>(BookmarkShowAll)
+  nmap <Leader>j <Plug>(BookmarkNext)
+  nmap <Leader>k <Plug>(BookmarkPrev)
+  nmap <Leader>c <Plug>(BookmarkClear)
+  nmap <Leader>x <Plug>(BookmarkClearAll)
 
   " these will also work with a [count] prefix
-  nmap <Leader>kk <Plug>BookmarkMoveUp
-  nmap <Leader>jj <Plug>BookmarkMoveDown
-  nmap <Leader>g <Plug>BookmarkMoveToLine
+  nmap <Leader>kk <Plug>(BookmarkMoveUp)
+  nmap <Leader>jj <Plug>(BookmarkMoveDown)
+  nmap <Leader>g <Plug>(BookmarkMoveToLine)
 <
 
 To prevent any default mappings from being created (default: 0):
@@ -319,16 +319,16 @@ ctrlp.vim is a Full path fuzzy file, buffer, mru, tag, ... finder for Vim.
 
 Additionally, when showing all your bookmarks, CtrlP is detected and the plugin
 will open *:CtrlPBookmark* instead of Vim's quickfix window. Note that
-|g:bookmark_auto_close| is no longer applied. Once opened, the window is managed 
+|g:bookmark_auto_close| is no longer applied. Once opened, the window is managed
 by CtrlP.
 
-With the CtrlP interface, when you select bookmarks, you can perform the 
+With the CtrlP interface, when you select bookmarks, you can perform the
 following actions:
 
 * Open the selected bookmarks in various ways (open to the right, open above,
   open in new tab, etc.)
 * And more...
- 
+
 For more information about CtrlP start reading |CtrlP@en|.
 
 https://github.com/ctrlpvim/ctrlp.vim

--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -174,7 +174,7 @@ function! BookmarkPrev()
 endfunction
 command! PrevBookmark call CallDeprecatedCommand('BookmarkPrev')
 command! BookmarkPrev call BookmarkPrev()
-command! CtrlPBookmark call ctrlp#init(ctrlp#bookmarks#id()) 
+command! CtrlPBookmark call ctrlp#init(ctrlp#bookmarks#id())
 
 function! BookmarkShowAll()
   if s:is_quickfix_win()
@@ -560,15 +560,20 @@ endfunction
 " Maps {{{
 
 function! s:register_mapping(command, shortcut, has_count)
-  if a:has_count
-    execute "nnoremap <silent> <Plug>". a:command ." :<C-u>". a:command ." v:count<CR>"
+  if get(g:, 'bookmark_use_old_plug_key_names', 0)
+    let command_plug_name = a:command
   else
-    execute "nnoremap <silent> <Plug>". a:command ." :". a:command ."<CR>"
+    let command_plug_name = "(" . a:command . ")"
   endif
-  if !hasmapto("<Plug>". a:command)
+  if a:has_count
+    execute "nnoremap <silent> <Plug>". command_plug_name ." :<C-u>". a:command ." v:count<CR>"
+  else
+    execute "nnoremap <silent> <Plug>". command_plug_name ." :". a:command ."<CR>"
+  endif
+  if !hasmapto("<Plug>". command_plug_name)
         \ && !get(g:, 'bookmark_no_default_key_mappings', 0)
         \ && maparg(a:shortcut, 'n') ==# ''
-    execute "nmap ". a:shortcut ." <Plug>". a:command
+    execute "nmap ". a:shortcut ." <Plug>". command_plug_name
   endif
 endfunction
 


### PR DESCRIPTION
Currently, due to the overlap in the names of ``<Plug>BookmarkClear`` and ``<Plug>BookmarkClearAll`` there is a timeout delay when calling the former. One popular convention to avoid this is to protect the plug names with parentheses (e.g.,  ``<Plug>(BookmarkClear)`` or ``<Plug>(BookmarkClearAll)``. This PR implements this, with the option to retain the older plug name convention for legacy support.