### PR TITLE
Fix: dissapperaing bookmark signs

### DIFF
--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -39,6 +39,7 @@ function! s:init(file)
     augroup bm_vim_enter
       autocmd!
       autocmd BufEnter * call s:set_up_auto_save(expand('<afile>:p'))
+      autocmd BufEnter * call BookmarkLoad(s:bookmark_save_file(g:bm_current_file), 0, 1)
     augroup END
   endif
   if g:bookmark_display_annotation ==# 1


### PR DESCRIPTION
This pr attempts to fix disappearing bookmark signs when using plugins like whichkey or when switching buffers / windows.

Edit: experienced more problems with bookmarks since nvim 0.7. I'm just using the fix/118 branch that fixes the problem with disappearing bookmarks when switching buffers / using whichkey but requires manually loading bookmarks to make bookmark-sign-characters appear when starting nvim