### PR TITLE
Add CocList to show all bookmarks for coc.nvim users.

### DIFF
--- a/autoload/bm.vim
+++ b/autoload/bm.vim
@@ -130,6 +130,30 @@ function! bm#all_lines(file)
   return keys(g:line_map[a:file])
 endfunction
 
+function! bm#coc_location_list()
+  let files = sort(bm#all_files())
+  let locations = []
+  for file in files
+    let line_nrs = sort(bm#all_lines(file), "bm#compare_lines")
+    for line_nr in line_nrs
+      let bookmark = bm#get_bookmark_by_line(file, line_nr)
+      let content = bookmark['annotation'] !=# ''
+            \ ? "Annotation: ". bookmark['annotation']
+            \ : (bookmark['content'] !=# ""
+            \   ? bookmark['content']
+            \   : "empty line")
+      let item = {
+            \ 'lnum': line_nr,
+            \ 'filename': file,
+            \ 'col': 1,
+            \ 'text': content
+        \ }
+      call add(locations, item)
+    endfor
+  endfor
+  return locations
+endfunction
+
 function! bm#location_list()
   let files = sort(bm#all_files())
   let locations = []

--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -33,6 +33,7 @@ call s:set('g:bookmark_center',               0 )
 call s:set('g:bookmark_location_list',        0 )
 call s:set('g:bookmark_disable_ctrlp',        0 )
 call s:set('g:bookmark_display_annotation',   0 )
+call s:set('g:bookmark_show_all_by_coclist',   0 )
 
 function! s:init(file)
   if g:bookmark_auto_save ==# 1 || g:bookmark_manage_per_buffer ==# 1
@@ -177,8 +178,36 @@ command! BookmarkPrev call BookmarkPrev()
 command! CtrlPBookmark call ctrlp#init(ctrlp#bookmarks#id()) 
 
 function! BookmarkShowAll()
-  let g:coc_jump_locations=bm#coc_location_list()
-  CocList --normal --auto-preview location
+  if g:bookmark_show_all_by_coclist ==# 1
+      let g:coc_jump_locations=bm#coc_location_list()
+      CocList --normal --auto-preview location
+  else
+      if s:is_quickfix_win()
+        q
+      else
+        call s:refresh_line_numbers()
+        if exists(':Unite')
+          exec ":Unite vim_bookmarks"
+        elseif exists(':CtrlP') == 2 && g:bookmark_disable_ctrlp == 0
+          exec ":CtrlPBookmark"
+        else
+          let oldformat = &errorformat    " backup original format
+          let &errorformat = "%f:%l:%m"   " custom format for bookmarks
+          if g:bookmark_location_list
+            lgetexpr bm#location_list()
+            belowright lopen
+          else
+            cgetexpr bm#location_list()
+            belowright copen
+          endif
+          augroup BM_AutoCloseCommand
+            autocmd!
+            autocmd WinLeave * call s:auto_close()
+          augroup END
+          let &errorformat = oldformat    " re-apply original format
+        endif
+      endif
+  endif
 endfunction
 command! ShowAllBookmarks call CallDeprecatedCommand('BookmarkShowAll')
 command! BookmarkShowAll call BookmarkShowAll()

--- a/plugin/bookmark.vim
+++ b/plugin/bookmark.vim
@@ -177,31 +177,8 @@ command! BookmarkPrev call BookmarkPrev()
 command! CtrlPBookmark call ctrlp#init(ctrlp#bookmarks#id()) 
 
 function! BookmarkShowAll()
-  if s:is_quickfix_win()
-    q
-  else
-    call s:refresh_line_numbers()
-    if exists(':Unite')
-      exec ":Unite vim_bookmarks"
-    elseif exists(':CtrlP') == 2 && g:bookmark_disable_ctrlp == 0
-      exec ":CtrlPBookmark"
-    else
-      let oldformat = &errorformat    " backup original format
-      let &errorformat = "%f:%l:%m"   " custom format for bookmarks
-      if g:bookmark_location_list
-        lgetexpr bm#location_list()
-        belowright lopen
-      else
-        cgetexpr bm#location_list()
-        belowright copen
-      endif
-      augroup BM_AutoCloseCommand
-        autocmd!
-        autocmd WinLeave * call s:auto_close()
-      augroup END
-      let &errorformat = oldformat    " re-apply original format
-    endif
-  endif
+  let g:coc_jump_locations=bm#coc_location_list()
+  CocList --normal --auto-preview location
 endfunction
 command! ShowAllBookmarks call CallDeprecatedCommand('BookmarkShowAll')
 command! BookmarkShowAll call BookmarkShowAll()


### PR DESCRIPTION
CocList can preview and jump to bookmarks, it's experience is better than quickfix for coc.nvim user. The g:bookmark_show_all_by_coclist is used to switch quickfix to coclist.